### PR TITLE
Support using PNG for preview images.

### DIFF
--- a/config/install/pdfpreview.settings.yml
+++ b/config/install/pdfpreview.settings.yml
@@ -5,3 +5,4 @@ filenames: 'human'
 show_description: FALSE
 tag: 'span'
 fallback_formatter: 'file_default'
+type: 'png'

--- a/config/schema/pdfpreview.schema.yml
+++ b/config/schema/pdfpreview.schema.yml
@@ -1,0 +1,27 @@
+pdfpreview.settings:
+  type: config_object
+  mapping:
+    quality:
+      type: integer
+      label: 'Quality of preview images'
+    size:
+      type: string
+      label: 'Size of the preview images'
+    path:
+      type: string
+      label: 'Location where preview images will be stored'
+    filenames:
+      type: string
+      label: 'Which approach to use to build filenames of previews (human-readable or md5)'
+    show_description:
+      type: boolean
+      label: 'Whether to show description by default'
+    tag:
+      type: string
+      label: 'The tag that should be used by default'
+    fallback_formatter:
+      type: string
+      label: 'Fallback formatter to be used by default'
+    type:
+      type: string
+      label: 'Image type to be used for the preview file'

--- a/pdfpreview.install
+++ b/pdfpreview.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for PDFpreview module.
+ */
+
+/**
+ * Adds output file configuration value to the module's settings.
+ */
+function pdfpreview_update_8001() {
+  \Drupal::configFactory()->getEditable('pdfpreview.settings')
+    ->set('type', 'jpg')
+    ->save();
+}

--- a/src/PDFPreviewGenerator.php
+++ b/src/PDFPreviewGenerator.php
@@ -107,7 +107,12 @@ class PDFPreviewGenerator {
     $this->toolkit->addArgument('-resize ' . escapeshellarg($this->config->get('size')));
     $this->toolkit->addArgument('-quality ' . escapeshellarg($this->config->get('quality')));
     $this->toolkit->addArgument('-pdfpreview');
-    $this->toolkit->setDestinationFormat('JPG');
+    if ($this->config->get('type') == 'png') {
+      $this->toolkit->setDestinationFormat('PNG');
+    }
+    else {
+      $this->toolkit->setDestinationFormat('JPG');
+    }
     $this->toolkit->setSourceFormat('PDF');
     $this->toolkit->setSourceLocalPath($local_path);
 
@@ -135,7 +140,14 @@ class PDFPreviewGenerator {
     else {
       $filename = md5('pdfpreview' . $file->id());
     }
-    return $output_path . '/' . $filename . '.jpg';
+
+    if ($this->config->get('type') == 'png') {
+      $extension = '.png';
+    }
+    else {
+      $extension = '.jpg';
+    }
+    return $output_path . '/' . $filename . $extension;
   }
 
 }

--- a/src/PDFPreviewSettingsForm.php
+++ b/src/PDFPreviewSettingsForm.php
@@ -85,6 +85,16 @@ class PDFPreviewSettingsForm extends ConfigFormBase {
       '#description' => t('This changes how filenames will be used on generated previews. If you change this after some files were generated, you must delete them manually.'),
       '#default_value' => $config->get('filenames'),
     );
+    $form['type'] = array(
+      '#type' => 'select',
+      '#title' => t('Preview image type'),
+      '#options' => array(
+        'jpg' => t('JPEG'),
+        'png' => t('PNG'),
+      ),
+      '#description' => t('The image file type that should be used when generating preview images.'),
+      '#default_value' => $config->get('type'),
+    );
     return parent::buildForm($form, $form_state);
   }
 
@@ -97,6 +107,7 @@ class PDFPreviewSettingsForm extends ConfigFormBase {
       ->set('size', $form_state->getValue('size'))
       ->set('quality', $form_state->getValue('quality'))
       ->set('filenames', $form_state->getValue('filenames'))
+      ->set('type', $form_state->getValue('type'))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
PNGs generally offer better quality for text heavy content. Considering a lot of PDFs are just that I'd propose to add support for this image type. For the same reason I'd suggest that we use PNG by default. 

This pull request implements that but keeps configuration value on jpeg for existing sites for backward compatibility. They can opt-in of course.